### PR TITLE
feature/#23: Input 컴포넌트 구현

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,84 @@
+import { useCallback } from 'react';
+import styled from '@emotion/styled';
+import { theme } from '@styles';
+
+interface WrapperInterface {
+  width?: number;
+}
+interface InputInterface {
+  labelText?: string;
+  width?: number;
+  type: string;
+  name?: string;
+  required?: boolean;
+  isValid?: boolean;
+  placeholder?: string;
+  value?: string | number;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  autoComplete?: string;
+}
+
+const Input = ({
+  labelText,
+  width = 21,
+  type,
+  name,
+  required = true,
+  isValid = true,
+  placeholder,
+  value,
+  onChange,
+  autoComplete = 'off',
+}: InputInterface) => {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange && onChange(e);
+    },
+    [onChange]
+  );
+
+  return (
+    <Wrapper width={width}>
+      <StyledLabel>{labelText}</StyledLabel>
+      <StyledInput
+        type={type}
+        name={name}
+        required={required}
+        isValid={isValid}
+        placeholder={placeholder}
+        value={value}
+        onChange={handleChange}
+        autoComplete={autoComplete}
+      />
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div<WrapperInterface>`
+  width: ${({ width }) => `${width}rem`};
+  text-align: center;
+  color: ${theme.$gray_dark};
+`;
+
+const StyledLabel = styled.label`
+  color: ${theme.$gray_dark};
+  margin-right: 0.8rem;
+`;
+
+const StyledInput = styled.input<InputInterface>`
+  width: 70%;
+  height: 2.5rem;
+  border: 0.1rem solid ${theme.$gray_medium};
+  padding: 1rem 1rem;
+  border-radius: 0.5rem;
+  box-sizing: border-box;
+
+  ::placeholder {
+    color: ${theme.$gray_medium};
+  }
+  &:focus {
+    border: 0.1rem solid black;
+  }
+`;
+
+export default Input;


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description -->

# 개요
* labelText 내용을 입력하면 라벨 있게 사용 가능(가로)
* 라벨과 Input을 감싸고 있는 width를 prop으로 받아서 사용.
Input의 width는 Wrapper의 70%
* 라벨 글자 수는 4글자 이하로 사용 권장


# 작업 내용
ex.
```
  <Input labelText="지출금액" type="text" placeholder="Input이다" />
  <Input type="text" placeholder="Input이다" width={25} />
```
![image](https://user-images.githubusercontent.com/95457808/181207394-b071b9fc-d3bd-4b34-a3e0-ac0095176084.png)


# 사진 (UI 컴포넌트 및 파일에 한해)


# 중점적으로 봐줬으면 하는 부분 (선택 사항)
close #23 