### PR TITLE
Refactor/#101 query client 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/src/.env
+++ b/src/.env
@@ -1,1 +1,0 @@
-REACT_APP_API_URL="http://ec2-3-34-252-245.ap-northeast-2.compute.amazonaws.com:8080/api/v1/""

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,19 +2,12 @@ import React from 'react';
 import { Global, ThemeProvider } from '@emotion/react';
 import { theme, reset } from '@styles';
 import { AppLayout, Loading } from '@components';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClientProvider } from 'react-query';
+import { queryClient } from '@api/react-query/queryClient';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import AppRouter from '@router';
 
 const App = () => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        // 임시로 staleTime 1분으로 정함. 추후 정책 정해야 함
-        staleTime: 60 * 1000,
-      },
-    },
-  });
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>

--- a/src/api/core/index.ts
+++ b/src/api/core/index.ts
@@ -1,20 +1,16 @@
 import axios from 'axios';
 
 const instance = axios.create({
-  baseURL:
-    'http://ec2-3-34-252-245.ap-northeast-2.compute.amazonaws.com:8080/api/v1/',
-  // baseURL: process.env.REACT_APP_API_URL,
-  withCredentials: true,
+  baseURL: process.env.REACT_APP_API_URL,
   headers: {
-    Authorization:
-      'bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJ0ZW53b25tb2EiLCJleHAiOjE2NTkzNDQ0MTksImlhdCI6MTY1OTM0MDgxOSwidXNlcklkIjozLCJlbWFpbCI6InRlc3RAdGVzdC5jb20ifQ.eee2xl1U7HYJ5nDtE5_6m5XKkFP5Hc3f5TjpNLcBOqrk27p1BjVQuaXK3fyVZ-85uos87wS4CcJu5rOpT3xWZw',
-    'Content-Type': 'application/json',
+    Authorization: '',
   },
 });
 
 instance.interceptors.response.use(
   (response) => response,
   (error) => {
+    // TODO: QueryClient를 통해 실제 에러 핸들링 처리
     if (error.response.status === 404 || error.response.status === 400) {
       // window.location.href = '/';
     }

--- a/src/api/core/index.ts
+++ b/src/api/core/index.ts
@@ -1,10 +1,24 @@
 import axios from 'axios';
+import tokenStorage from '@utils/storage/TokenStorage';
+
+const getJWTHeader = (): Record<string, string> => {
+  return { Authorization: `Bearer ${tokenStorage.getAccessToken()}` };
+};
 
 const instance = axios.create({
   baseURL: process.env.REACT_APP_API_URL,
   headers: {
-    Authorization: '',
+    ...getJWTHeader(),
   },
+});
+
+instance.interceptors.request.use((config) => {
+  return {
+    ...config,
+    headers: {
+      ...getJWTHeader(),
+    },
+  };
 });
 
 instance.interceptors.response.use(

--- a/src/api/react-query/queryClient.ts
+++ b/src/api/react-query/queryClient.ts
@@ -1,0 +1,31 @@
+import { QueryClient } from 'react-query';
+
+// TODO: 소니 에러핸들링 연결
+const queryErrorHandler = (error: unknown): void => {
+  const message =
+    error instanceof Error ? error.message : 'error connecting to server';
+  alert(message);
+};
+
+export const queryClient = new QueryClient({
+  /**
+   * @description
+   * [임시 defaultOptions]
+   * staleTime 1분으로 정함.
+   * cacheTime 10분으로 정함.
+   * 추후 정책 정해야 함
+   */
+  defaultOptions: {
+    queries: {
+      onError: queryErrorHandler,
+      staleTime: 60 * 1000,
+      cacheTime: 600 * 1000,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+    },
+    mutations: {
+      onError: queryErrorHandler,
+    },
+  },
+});


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호 description -->

# 개요
<!-- 가능한 한 문장으로 요약한 PR 제목 -->

# 작업 내용
1. query-client 모듈 분리 b47d6243d8260a0f1ca4eb49089cb9a603d64475
2. gitIgnore 에 .env 관련 추가 a4e727a7a479dea9bdac5f9f45be7536c1cb0c17
3. axios instance에 JWT토큰 interceptor 관련 함수 추가 e177cb43bf53fa98989dbf5fb14e09a5b1bdaaa5

Close #101

# 사진 (UI 컴포넌트 및 파일에 한해)

로그인 상태에서 아래와 같이 카테고리 API 정상호출되는 것 확인했습니다~
다른 페이지 이동 후에도 다시 들어갔는데, 캐싱되어 로딩 돌지 않는 것도 확인했어요! 

![Screen Recording 2022-08-03 at 3 31 04 PM](https://user-images.githubusercontent.com/64780560/182539817-2420f742-667b-4962-bd10-8829996995c3.gif)

