### PR TITLE
Feature/#134 가계부 일일, 월간 조회 페이지 UI

### DIFF
--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -23,6 +23,7 @@ const Line = styled.hr<DividerInterface>`
 
 const dividerType = {
   horizontal: css`
+    margin: 0.5rem 0;
     display: block;
     height: 1px;
   `,

--- a/src/components/TopNavMonthSelector.tsx
+++ b/src/components/TopNavMonthSelector.tsx
@@ -1,7 +1,14 @@
+import styled from '@emotion/styled';
 import { TopNavOutline, DateSelector } from '@components';
 import type { DateSelectorProps } from '@components/DateSelector';
+import { Search } from 'react-feather';
+import { Link } from 'react-router-dom';
 
-const TopNavMonthSelector: React.FC<DateSelectorProps> = (props) => {
+const TopNavMonthSelector = <
+  T extends DateSelectorProps & { isShowSearch?: boolean }
+>(
+  props: T
+) => {
   return (
     <TopNavOutline>
       <DateSelector
@@ -9,8 +16,15 @@ const TopNavMonthSelector: React.FC<DateSelectorProps> = (props) => {
         onChangePev={props.onChangePev}
         onChangeNext={props.onChangeNext}
       />
+      <SearchLink to="/search">
+        <Search />
+      </SearchLink>
     </TopNavOutline>
   );
 };
 
 export default TopNavMonthSelector;
+
+const SearchLink = styled(Link)`
+  padding: 1rem;
+`;

--- a/src/components/TopNavMonthSelector.tsx
+++ b/src/components/TopNavMonthSelector.tsx
@@ -4,11 +4,7 @@ import type { DateSelectorProps } from '@components/DateSelector';
 import { Search } from 'react-feather';
 import { Link } from 'react-router-dom';
 
-const TopNavMonthSelector = <
-  T extends DateSelectorProps & { isShowSearch?: boolean }
->(
-  props: T
-) => {
+const TopNavMonthSelector = <T extends DateSelectorProps>(props: T) => {
   return (
     <TopNavOutline>
       <DateSelector

--- a/src/components/TopNavOutline.tsx
+++ b/src/components/TopNavOutline.tsx
@@ -10,6 +10,8 @@ const NavBar: React.FC<NavOutlineProps> = (props) => {
 
 const NavBarContainer = styled.div`
   display: flex;
+  justify-content: space-between;
+  align-items: center;
   height: 3.6rem;
   width: 100%;
   position: relative;

--- a/src/components/account/AccountBookDailyCard.tsx
+++ b/src/components/account/AccountBookDailyCard.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { AccountBookDailySum, AccountBookDailyItem } from '@components/account';
 
-const AccountBookDailyCard: React.FC<{
-  items: DailyAccount;
-}> = (props) => {
+const AccountBookDailyCard = <T extends { items: DailyAccount }>(props: T) => {
   return (
     <Container>
       <AccountBookDailySum
@@ -13,7 +11,7 @@ const AccountBookDailyCard: React.FC<{
         registerDate={props.items.registerDate}
       />
       {props.items.dayDetails.map((item) => (
-        <AccountBookDailyItem key={item.id} item={item} />
+        <AccountBookDailyItem key={item.id.toString()} item={item} />
       ))}
     </Container>
   );

--- a/src/components/account/AccountBookDailyCard.tsx
+++ b/src/components/account/AccountBookDailyCard.tsx
@@ -10,8 +10,11 @@ const AccountBookDailyCard = <T extends { items: DailyAccount }>(props: T) => {
         dayExpenditure={props.items.expenditureSum}
         registerDate={props.items.registerDate}
       />
-      {props.items.dayDetails.map((item) => (
-        <AccountBookDailyItem key={item.id.toString()} item={item} />
+      {props.items.dayDetails.map((item, idx) => (
+        <AccountBookDailyItem
+          key={`account-single-${item.id}-${item.type}-${idx}`}
+          item={item}
+        />
       ))}
     </Container>
   );

--- a/src/components/account/AccountBookDailyItem.tsx
+++ b/src/components/account/AccountBookDailyItem.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { theme } from '@styles';
-import { dateFormatter } from '@utils/formatter/dateFormatter';
 import { useNavigate } from 'react-router-dom';
-import { currencyFormatter } from '@utils/formatter';
-
-const colorType = {
-  INCOME: theme.$blue,
-  EXPENDITURE: theme.$red,
-};
-
+import { dateFormatter, currencyFormatter } from '@utils/formatter';
 const AccountBookDailyItem: React.FC<{ item: SingleAccount }> = (props) => {
   const navigate = useNavigate();
 
@@ -19,43 +11,58 @@ const AccountBookDailyItem: React.FC<{ item: SingleAccount }> = (props) => {
   }`;
 
   return (
-    <Container onClick={() => navigate(accountUpdatePath)}>
-      <P color={theme.$gray_dark}>{props.item.categoryName}</P>
+    <Wrapper onClick={() => navigate(accountUpdatePath)}>
       <div>
-        <P color={theme.$black}>{props.item.content}</P>
-        <P color={theme.$gray_medium}>
-          {dateFormatter(props.item.registerTime, 'HOUR_MINUTE')}
-        </P>
+        <p>{dateFormatter(props.item.registerTime, 'HOUR_MINUTE')}</p>
       </div>
-      <P color={colorType[props.item.type]}>
-        {currencyFormatter(props.item.amount)}
-      </P>
-    </Container>
+      <div>
+        <p>{props.item.categoryName}</p>
+        <p>{props.item.content}</p>
+      </div>
+      <div>
+        <StyledParagraph type={props.item.type}>
+          {currencyFormatter(props.item.amount)}원
+        </StyledParagraph>
+      </div>
+    </Wrapper>
   );
 };
 
 export default AccountBookDailyItem;
 
-const Container = styled.div(
-  {
-    display: 'grid',
-    gridTemplateColumns: '1fr 2fr 1fr',
-    paddingBottom: '1rem',
-    borderBottom: '1px solid gray',
-    minHeight: '4rem',
-    alignItems: 'center',
-    margin: '0 2rem',
-    '>p:nth-of-type(2)': {
-      textAlign: 'right',
-    },
-  },
-  (props) => ({ color: props.color })
-);
+const Wrapper = styled.div<{ type?: string }>`
+  display: grid;
+  grid-template-columns: 1fr 2fr 1fr;
+  align-items: center;
+  font-size: 1.2rem;
+  font-weight: 500;
+  padding: 2rem 2rem;
+  border-bottom: 3px solid ${(props) => props.theme.$gray_light};
 
-const P = styled.p(
-  {
-    fontSize: '1rem',
-    paddingTop: '1rem',
-  },
-  ({ color }) => ({ color, fontSize: '1rem' })
-);
+  & div:nth-of-type(1) {
+    & p:nth-of-type(1) {
+      font-size: 0.8rem;
+      color: ${(props) => props.theme.$gray_medium};
+    }
+  }
+
+  & div:nth-of-type(2) {
+    text-align: left;
+    & p:nth-of-type(2) {
+      font-size: 0.7rem;
+      color: ${(props) => props.theme.$gray_medium};
+    }
+  }
+  & div:nth-of-type(3) {
+    text-align: right;
+  }
+`;
+
+const StyledParagraph = styled.p<{ type?: string }>`
+  color: ${(props) =>
+    props.type === 'INCOME'
+      ? props.theme.$blue
+      : props.type === 'EXPENDITURE'
+      ? props.theme.$red
+      : props.theme.$black};
+`;

--- a/src/components/account/AccountBookDailySum.tsx
+++ b/src/components/account/AccountBookDailySum.tsx
@@ -3,14 +3,13 @@ import styled from '@emotion/styled';
 import { theme } from '@styles';
 import { dateFormatter, currencyFormatter } from '@utils/formatter';
 
-const AccountBookDailySum: React.FC<DailySum> = (props) => {
+const AccountBookDailySum = <T extends DailySum>(props: T) => {
   return (
     <Container>
-      <StrongText>{dateFormatter(props.registerDate, 'DAY')}</StrongText>
-      <FilledText>{dateFormatter(props.registerDate, 'WEEKDAY')}</FilledText>
-      <p>{dateFormatter(props.registerDate, 'YEAR_MONTH_DAY_DASH')}</p>
-      <P color={theme.$blue}>{currencyFormatter(props.dayIncome)}</P>
-      <P color={theme.$red}>{currencyFormatter(props.dayExpenditure)}</P>
+      <p>{dateFormatter(props.registerDate, 'DAY')}</p>
+      <p>{dateFormatter(props.registerDate, 'WEEKDAY')}</p>
+      <p color={theme.$blue}>{currencyFormatter(props.dayIncome)}원</p>
+      <p color={theme.$red}>{currencyFormatter(props.dayExpenditure)}원</p>
     </Container>
   );
 };
@@ -18,6 +17,8 @@ const AccountBookDailySum: React.FC<DailySum> = (props) => {
 export default AccountBookDailySum;
 
 const Container = styled.div`
+  display: grid;
+  grid-template-columns: 1fr repeat(4);
   width: 100%;
   height: 2rem;
   padding: 2rem 0;
@@ -25,25 +26,27 @@ const Container = styled.div`
   align-items: center;
   justify-content: space-around;
   border-bottom: solid 1px lightgray;
-`;
 
-const StrongText = styled.strong`
-  font-size: 1.6rem;
-  font-weight: bolder;
+  & p:nth-of-type(1) {
+    font-size: 1.6rem;
+    font-weight: bolder;
+  }
+  & p:nth-of-type(2) {
+    width: 5.2rem;
+    background: gray;
+    padding: 0.3rem;
+    text-align: center;
+    border-radius: 8px;
+    color: white;
+  }
+  & p:nth-of-type(3) {
+    font-size: 1rem;
+    font-weight: 500;
+    color: ${(props) => props.theme.$blue};
+  }
+  & p:nth-of-type(4) {
+    font-size: 1rem;
+    font-weight: 500;
+    color: ${(props) => props.theme.$red};
+  }
 `;
-
-const FilledText = styled.p`
-  width: 5.2rem;
-  background: gray;
-  padding: 0.3rem;
-  text-align: center;
-  border-radius: 8px;
-  color: white;
-`;
-
-const P = styled.p(
-  {
-    fontSize: '1rem',
-  },
-  ({ color }) => ({ color })
-);

--- a/src/components/account/AccountBookMonthlyCard.tsx
+++ b/src/components/account/AccountBookMonthlyCard.tsx
@@ -27,7 +27,7 @@ const Card = styled.div`
   padding: 4rem 2rem;
   margin: 0 1rem;
   border-bottom: 1px solid ${(props) => props.theme.$gray_medium};
-  & div:nth-child(1) {
+  & div:nth-of-type(1) {
     background: #ffc266;
     border-radius: 0.7rem;
     padding: 0.5rem;
@@ -35,16 +35,16 @@ const Card = styled.div`
     font-size: 1.2rem;
     font-weight: 500;
   }
-  & div:nth-child(2) {
+  & div:nth-of-type(2) {
     text-align: right;
   }
-  & p:nth-child(1) {
+  & p:nth-of-type(1) {
     color: ${(props) => props.theme.$blue};
   }
-  & p:nth-child(2) {
+  & p:nth-of-type(2) {
     color: ${(props) => props.theme.$red};
   }
-  & p:nth-child(3) {
+  & p:nth-of-type(3) {
     margin-top: 1rem;
     font-size: 1.2rem;
     border-top: 1px solid ${(props) => props.theme.$gray_medium};

--- a/src/components/account/AccountBookMonthlyCard.tsx
+++ b/src/components/account/AccountBookMonthlyCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { currencyFormatter } from '@utils/formatter';
-
+import { Divider } from '@components';
 const AccountBookMonthlyCard = <T extends { item: MonthlyAccount }>(
   props: T
 ) => {
@@ -11,6 +11,7 @@ const AccountBookMonthlyCard = <T extends { item: MonthlyAccount }>(
       <div>
         <p>{currencyFormatter(props.item.incomeSum)}원</p>
         <p>{currencyFormatter(props.item.expenditureSum)}원</p>
+        <Divider />
         <p>{currencyFormatter(props.item.totalSum)}원</p>
       </div>
     </Card>
@@ -26,7 +27,7 @@ const Card = styled.div`
   height: 3rem;
   padding: 4rem 2rem;
   margin: 0 1rem;
-  border-bottom: 1px solid ${(props) => props.theme.$gray_medium};
+  border-bottom: 1px solid ${(props) => props.theme.$gray_light};
   & div:nth-of-type(1) {
     background: #ffc266;
     border-radius: 0.7rem;
@@ -45,8 +46,6 @@ const Card = styled.div`
     color: ${(props) => props.theme.$red};
   }
   & p:nth-of-type(3) {
-    margin-top: 1rem;
     font-size: 1.2rem;
-    border-top: 1px solid ${(props) => props.theme.$gray_medium};
   }
 `;

--- a/src/components/account/AccountBookMonthlyCard.tsx
+++ b/src/components/account/AccountBookMonthlyCard.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { currencyFormatter } from '@utils/formatter';
+
+const AccountBookMonthlyCard = <T extends { item: MonthlyAccount }>(
+  props: T
+) => {
+  return (
+    <Card>
+      <div>{props.item.month}월</div>
+      <div>
+        <p>{currencyFormatter(props.item.incomeSum)}원</p>
+        <p>{currencyFormatter(props.item.expenditureSum)}원</p>
+      </div>
+    </Card>
+  );
+};
+
+export default AccountBookMonthlyCard;
+
+const Card = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 3rem;
+  padding: 3rem 2rem;
+  margin: 0 1rem;
+  border-bottom: 1px solid ${(props) => props.theme.$gray_medium};
+  & div:nth-child(1) {
+    background: #ffc266;
+    border-radius: 0.7rem;
+    padding: 0.5rem;
+    color: ${(props) => props.theme.$white};
+    font-size: 1.2rem;
+    font-weight: 500;
+  }
+  & div:nth-child(2) {
+    padding: 1rem 0;
+    text-align: right;
+  }
+  & p:nth-child(1) {
+    color: ${(props) => props.theme.$blue};
+  }
+  & p:nth-child(2) {
+    color: ${(props) => props.theme.$red};
+  }
+`;

--- a/src/components/account/AccountBookMonthlyCard.tsx
+++ b/src/components/account/AccountBookMonthlyCard.tsx
@@ -11,6 +11,7 @@ const AccountBookMonthlyCard = <T extends { item: MonthlyAccount }>(
       <div>
         <p>{currencyFormatter(props.item.incomeSum)}원</p>
         <p>{currencyFormatter(props.item.expenditureSum)}원</p>
+        <p>{currencyFormatter(props.item.totalSum)}원</p>
       </div>
     </Card>
   );
@@ -23,7 +24,7 @@ const Card = styled.div`
   justify-content: space-between;
   align-items: center;
   height: 3rem;
-  padding: 3rem 2rem;
+  padding: 4rem 2rem;
   margin: 0 1rem;
   border-bottom: 1px solid ${(props) => props.theme.$gray_medium};
   & div:nth-child(1) {
@@ -35,7 +36,6 @@ const Card = styled.div`
     font-weight: 500;
   }
   & div:nth-child(2) {
-    padding: 1rem 0;
     text-align: right;
   }
   & p:nth-child(1) {
@@ -43,5 +43,10 @@ const Card = styled.div`
   }
   & p:nth-child(2) {
     color: ${(props) => props.theme.$red};
+  }
+  & p:nth-child(3) {
+    margin-top: 1rem;
+    font-size: 1.2rem;
+    border-top: 1px solid ${(props) => props.theme.$gray_medium};
   }
 `;

--- a/src/components/account/TabsDisplayAccountSum.tsx
+++ b/src/components/account/TabsDisplayAccountSum.tsx
@@ -1,51 +1,47 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { theme } from '@styles';
+import { currencyFormatter } from '@utils/formatter';
 
-interface TabItem {
-  value: string | number;
-  title: string;
-  color?: string;
-}
-
-interface TabsProps {
-  tabItems: TabItem[];
-}
-
-const TabsDisplayAccountSum: React.FC<TabsProps> = ({ tabItems }) => {
+const TabsDisplayAccountSum = (props: { sumResult: AccountBookSum }) => {
   return (
-    <TabListContainer>
-      {tabItems.map((item) => (
-        <Tab key={item.title}>
-          <P>{item.title}</P>
-          <P color={item.color}>{item.value}</P>
-        </Tab>
-      ))}
-    </TabListContainer>
+    <SumListSection>
+      <li>
+        <p>수입</p>
+        <p> {currencyFormatter(props.sumResult.incomeSum)} 원</p>
+      </li>
+      <li>
+        <p>지출</p>
+        <p> {currencyFormatter(props.sumResult.expenditureSum)} 원</p>
+      </li>
+      <li>
+        <p>합계</p>
+        <p> {currencyFormatter(props.sumResult.totalSum)} 원</p>
+      </li>
+    </SumListSection>
   );
 };
 
 export default TabsDisplayAccountSum;
 
-const P = styled.p(
-  {
-    fontSize: '1rem',
-  },
-  (props) => ({ color: props.color })
-);
-
-const TabListContainer = styled.div`
+const SumListSection = styled.ul`
   width: 100%;
-  height: 5rem;
-  display: flex;
-`;
-
-const Tab = styled.div`
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
-  justify-content: center;
-  align-items: center;
-  border-bottom: 1px solid ${theme.$gray_dark};
-  background-color: ${theme.$white};
+  padding: 0.5rem 1rem;
+  border-bottom: 5px solid ${(props) => props.theme.$gray_light};
+
+  & li {
+    display: flex;
+    justify-content: space-between;
+    font-weight: 300;
+    padding: 0.5rem 0;
+
+    & :first-child {
+      font-size: 1rem;
+      font-weight: 400;
+    }
+    & :last-child {
+      font-size: 1rem;
+    }
+  }
 `;

--- a/src/components/account/TabsDisplayAccountSum.tsx
+++ b/src/components/account/TabsDisplayAccountSum.tsx
@@ -36,11 +36,11 @@ const SumListSection = styled.ul`
     font-weight: 300;
     padding: 0.5rem 0;
 
-    & :first-child {
+    & p:first-of-type {
       font-size: 1rem;
       font-weight: 400;
     }
-    & :last-child {
+    & p:last-of-type {
       font-size: 1rem;
     }
   }

--- a/src/components/account/TabsNavigation.tsx
+++ b/src/components/account/TabsNavigation.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import styled from '@emotion/styled';
-import { theme } from '@styles';
 
 type TabItem = {
   path: string;
   title: string;
 };
 
-interface TabsProps {
-  tabItems: TabItem[];
-}
-
-const TabsNavigation: React.FC<TabsProps> = (props) => {
+const TabsNavigation = <T extends { tabItems: TabItem[] }>(props: T) => {
   return (
     <TabListContainer>
       {props.tabItems.map((item) => (
@@ -32,23 +27,21 @@ export default TabsNavigation;
 
 const TabListContainer = styled.div`
   width: 100%;
-  height: 3rem;
   display: flex;
 `;
 
 const TabNav = styled(NavLink)`
-  display: flex;
+  text-align: center;
+  padding: 0.7rem 0;
   flex-grow: 1;
-  justify-content: center;
-  align-items: center;
+  font-size: 1.2rem;
+  font-weight: 500;
   cursor: pointer;
-  border-bottom: 1px solid ${theme.$gray_dark};
-  color: ${theme.$gray_dark};
-  background-color: ${theme.$white};
-
+  color: ${(props) => props.theme.$gray_dark};
+  background-color: ${(props) => props.theme.$white};
   &.active {
-    background-color: ${theme.$secondary};
-    border-bottom: 1px solid ${theme.$primary};
-    color: ${theme.$primary};
+    font-weight: bold;
+    border-bottom: 3px solid ${(props) => props.theme.$primary};
+    color: ${(props) => props.theme.$primary};
   }
 `;

--- a/src/components/account/index.ts
+++ b/src/components/account/index.ts
@@ -6,8 +6,10 @@ import AccountBookDailyCard from './AccountBookDailyCard';
 import AccountForm from './AccountForm';
 import CategoryBox from './CategoryBox';
 import PlusButton from './PlusButton';
+import AccountBookMonthlyCard from './AccountBookMonthlyCard';
 
 export {
+  AccountBookMonthlyCard,
   TabsDisplayAccountSum,
   TabsNavigation,
   AccountBookDailySum,

--- a/src/hooks/account/useAccountBookDaily.ts
+++ b/src/hooks/account/useAccountBookDaily.ts
@@ -13,7 +13,7 @@ const fetchAccountBook = async (
     `/account-book/daily/${date}-01`,
     {
       params: {
-        size: 1,
+        size: 5,
         page: pageParam,
       },
     }

--- a/src/pages/accountBook/index.tsx
+++ b/src/pages/accountBook/index.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { theme } from '@styles';
 import { BottomNavigation, TopNavMonthSelector } from '@components';
 import { TabsDisplayAccountSum, TabsNavigation } from '@components/account';
 import { Outlet, useLocation } from 'react-router-dom';
 import { useMonthSelector } from '@hooks';
-import { currencyFormatter } from '@utils/formatter';
 import { useAccountBookSum } from '@hooks/account';
 import type { DateSelectorProps } from '@components/DateSelector';
 
@@ -34,9 +32,7 @@ const AccountBook = () => {
   if (!isAccountBookPath(path)) {
     throw new Error('정상적이지 않은 경로로 접근했습니다.');
   }
-
-  const isDaily = path === 'daily';
-  const sumResult = isDaily ? monthSumResult : yearSumResult;
+  const sumResult = path === 'monthly' ? yearSumResult : monthSumResult;
 
   const dateSelectorHandlers: Record<AccountBookPathTypes, DateSelectorProps> =
     {
@@ -72,23 +68,6 @@ const AccountBook = () => {
     },
   ];
 
-  const ACCOUNT_TYPE = [
-    {
-      value: currencyFormatter(sumResult.incomeSum),
-      title: '수입',
-      color: theme.$blue,
-    },
-    {
-      value: currencyFormatter(sumResult.expenditureSum),
-      title: '지출',
-      color: theme.$red,
-    },
-    {
-      value: currencyFormatter(sumResult.totalSum),
-      title: '합계',
-    },
-  ];
-
   return (
     <>
       <TopNavMonthSelector
@@ -97,7 +76,7 @@ const AccountBook = () => {
         onChangeNext={dateSelectorHandlers[path].onChangeNext}
       />
       <TabsNavigation tabItems={ACCOUNT_BOOK_TAB_ITEMS} />
-      <TabsDisplayAccountSum tabItems={ACCOUNT_TYPE} />
+      <TabsDisplayAccountSum sumResult={sumResult} />
       <Outlet />
       <BottomNavigation />
     </>

--- a/src/pages/accountBook/index.tsx
+++ b/src/pages/accountBook/index.tsx
@@ -22,11 +22,12 @@ const AccountBook = () => {
   const { pathname } = useLocation();
   const [, , path] = pathname.split('/');
 
-  type AccountBookPathTypes = 'daily' | 'monthly';
+  type AccountBookPathTypes = 'daily' | 'monthly' | 'calendar';
 
   const isAccountBookPath = (path: string): path is AccountBookPathTypes => {
     if (path === 'daily') return true;
     if (path === 'monthly') return true;
+    if (path === 'calendar') return true;
     return false;
   };
 
@@ -49,12 +50,21 @@ const AccountBook = () => {
         onChangePev: handlePrevYear,
         onChangeNext: handleNextYear,
       },
+      calendar: {
+        date: monthDate,
+        onChangePev: handlePrevMonth,
+        onChangeNext: handleNextMonth,
+      },
     };
 
   const ACCOUNT_BOOK_TAB_ITEMS = [
     {
       path: 'daily',
       title: '일일',
+    },
+    {
+      path: 'calendar',
+      title: '달력',
     },
     {
       path: 'monthly',

--- a/src/pages/accountBookDaily/index.tsx
+++ b/src/pages/accountBookDaily/index.tsx
@@ -5,7 +5,7 @@ import { AccountBookDailyCard, PlusButton } from '@components/account';
 import { GoTopButton, Spinner, CoinIcon } from '@components';
 import useAccountBookDaily from '@hooks/account/useAccountBookDaily';
 
-const AccountBookDaily: React.FC = () => {
+const AccountBookDaily = () => {
   const [visible, setVisible] = useState(false);
   const navigate = useNavigate();
 
@@ -80,8 +80,8 @@ const AccountBookDaily: React.FC = () => {
   return (
     <CardArea>
       <div ref={topRef} />
-      {dailyAccounts?.map((item: DailyAccount, idx: number) => (
-        <AccountBookDailyCard key={idx} items={item} />
+      {dailyAccounts?.map((item: DailyAccount, index: number) => (
+        <AccountBookDailyCard key={item.registerDate + index} items={item} />
       ))}
       <div ref={loadingRef}>{hasNextPage && <Spinner />}</div>
       <GoTopButton topRef={topRef} isVisible={visible} />

--- a/src/pages/accountBookDaily/index.tsx
+++ b/src/pages/accountBookDaily/index.tsx
@@ -80,8 +80,11 @@ const AccountBookDaily = () => {
   return (
     <CardArea>
       <div ref={topRef} />
-      {dailyAccounts?.map((item: DailyAccount, index: number) => (
-        <AccountBookDailyCard key={item.registerDate + index} items={item} />
+      {dailyAccounts?.map((item: DailyAccount, idx) => (
+        <AccountBookDailyCard
+          key={`daily-account-${item.registerDate}-${idx}`}
+          items={item}
+        />
       ))}
       <div ref={loadingRef}>{hasNextPage && <Spinner />}</div>
       <GoTopButton topRef={topRef} isVisible={visible} />

--- a/src/pages/accountBookMonthly/index.tsx
+++ b/src/pages/accountBookMonthly/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { currencyFormatter } from '@utils/formatter';
 import { useAccountBookMonthly } from '@hooks/account';
-import dayjs from 'dayjs';
+import { AccountBookMonthlyCard } from '@components/account';
 
 const AccountBookMonthly = () => {
   const { data } = useAccountBookMonthly();
@@ -13,36 +12,18 @@ const AccountBookMonthly = () => {
     return <p>등록 된 데이터가 없습니다.</p>;
   }
 
-  const monthRangeFormatter = (month: number) => {
-    const startOfMonth = dayjs().date(month).startOf('month').format('MM.DD');
-    const endOfMonth = dayjs().date(month).endOf('month').format('MM.DD');
-    return `${startOfMonth} ~ ${endOfMonth}`;
-  };
-
   return (
-    <>
+    <CardArea>
       {data.map((item: MonthlyAccount, idx: number) => (
-        <Card key={idx}>
-          <div>
-            <p>{item.month}월</p>
-            <p>{monthRangeFormatter(item.month)}</p>
-          </div>
-          <div>{currencyFormatter(item.incomeSum)}</div>
-          <div>{currencyFormatter(item.expenditureSum)}</div>
-        </Card>
+        <AccountBookMonthlyCard item={item} key={idx} />
       ))}
-    </>
+    </CardArea>
   );
 };
 
 export default AccountBookMonthly;
 
-const Card = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  align-items: center;
-  text-align: center;
-  height: 3rem;
+const CardArea = styled.div`
   width: 100%;
-  border-bottom: 1px solid ${(props) => props.theme.$gray_medium};
+  overflow-y: scroll;
 `;


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호 description -->

# 개요
<!-- 가능한 한 문장으로 요약한 PR 제목 -->
가계부 일일, 월간 조회 페이지 UI
Issue #134 

# 작업 내용
<!-- 해당 브랜치에서 작업한 단위(Ex. Commit 단위) -->
1. 가계부 조회 페이지 UI 수정 명세 - 피그마
 2. TopNavigation 돋보기 아이콘 추가
 3. TopNavigation 돋보기 아이콘 클릭 시 검색 페이지 라우팅
 4. 가계부 공통 수입, 지출, 합계 노출 컴포넌트 UI 수정 (AccountBookDailySum)
 5. 가계부 공통 일일, 캘린더, 월간 탭 컴포넌트 UI 수정 (TabsNavigation)
 6. 가계부 일일 조회 페이지 UI
 8. 가계부 월간 조회 페이지 UI
 9. 가계부 일일 조회 API 사이즈 param 수정 fba65d28b272501f9c79d80efea5e1ba1d39ac0f
     - 1 사이즈의 반환값이 적어 임시처리 하였고, 해당 API는 페이징 방식 리팩토링이 필요하여 수정 작업중에 있습니다.


#134  에 해당하는 이슈에 남은 로딩, 에러 UI 처리는 적합한 아이콘을 찾은 후 따로 이슈를 분리해서 작업하도록 하겠습니다~



# 사진 (UI 컴포넌트 및 파일에 한해)
<img width="486" alt="Screen Shot 2022-08-11 at 1 38 12 AM" src="https://user-images.githubusercontent.com/64780560/183965424-054a1ea1-448e-4b00-b69c-3201d52d4c52.png">

<img width="486" alt="Screen Shot 2022-08-11 at 1 38 04 AM" src="https://user-images.githubusercontent.com/64780560/183965392-656a746b-8d3a-46c0-a5c0-4db9f357c47c.png">

