### PR TITLE
Fix/#218 라우터 queryString, dateSelector 컴포넌트 싱크 오류

### DIFF
--- a/src/hooks/useMonthSelector.ts
+++ b/src/hooks/useMonthSelector.ts
@@ -1,6 +1,6 @@
 import { useReducer, useEffect } from 'react';
-import dayjs from 'dayjs';
 import { useSearchParams } from 'react-router-dom';
+import dayjs from 'dayjs';
 
 type ActionType = 'NEXT_MONTH' | 'PREV_MONTH' | 'NEXT_YEAR' | 'PREV_YEAR';
 interface ActionInterface {
@@ -22,9 +22,12 @@ const timeReducer = (state: dayjs.Dayjs, action: ActionInterface) => {
 
 const useMonthSelector = (initialDate = dayjs()) => {
   const [searchParams] = useSearchParams();
+  const isValidDate =
+    searchParams.get('date') && searchParams.get('date') !== 'Invalid Date';
+
   const [date, dispatchMonth] = useReducer(
     timeReducer,
-    dayjs(searchParams.get('date')) || initialDate
+    isValidDate ? initialDate : dayjs()
   );
   const [, setSearchParams] = useSearchParams();
 
@@ -45,7 +48,7 @@ const useMonthSelector = (initialDate = dayjs()) => {
   };
 
   useEffect(() => {
-    setSearchParams({ date: date.format('YYYY-MM-DD') });
+    setSearchParams({ date: date.format('YYYY-MM') });
   }, [date]);
 
   return {

--- a/src/hooks/useMonthSelector.ts
+++ b/src/hooks/useMonthSelector.ts
@@ -21,7 +21,11 @@ const timeReducer = (state: dayjs.Dayjs, action: ActionInterface) => {
 };
 
 const useMonthSelector = (initialDate = dayjs()) => {
-  const [date, dispatchMonth] = useReducer(timeReducer, initialDate);
+  const [searchParams] = useSearchParams();
+  const [date, dispatchMonth] = useReducer(
+    timeReducer,
+    dayjs(searchParams.get('date')) || initialDate
+  );
   const [, setSearchParams] = useSearchParams();
 
   const handleNextMonth = () => {

--- a/src/pages/accountBook/index.tsx
+++ b/src/pages/accountBook/index.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { useNavigate, Outlet, useLocation } from 'react-router-dom';
+import {
+  useNavigate,
+  Outlet,
+  useLocation,
+  useSearchParams,
+} from 'react-router-dom';
 import { BottomNavigation, TopNavMonthSelector } from '@components';
 import {
   TabsDisplayAccountSum,
@@ -9,11 +14,13 @@ import {
 import { useMonthSelector } from '@hooks';
 import { useAccountBookSum } from '@hooks/account';
 import type { DateSelectorProps } from '@components/DateSelector';
+import dayjs from 'dayjs';
 
 type AccountBookPathTypes = 'daily' | 'monthly' | 'calendar';
 
 const AccountBook = () => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const {
     monthDate,
     yearDate,
@@ -21,7 +28,7 @@ const AccountBook = () => {
     handleNextMonth,
     handleNextYear,
     handlePrevYear,
-  } = useMonthSelector();
+  } = useMonthSelector(dayjs(searchParams.get('date')));
   const { monthSumResult, yearSumResult } = useAccountBookSum();
 
   const { pathname } = useLocation();


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호 description -->

# 개요
<!-- 가능한 한 문장으로 요약한 PR 제목 -->
쿼리스트링 값과 dateSelector 컴포넌트 싱크 미일치 오류 수정

# 작업 내용
<!-- 해당 브랜치에서 작업한 단위(Ex. Commit 단위) -->
Close #218 

새로고침시 queryString과 dateSelector 값이 일치하지 않는 오류 수정했습니다.

임시 수정상태라서 이후에 useMonthSelector는 이후 추가 리팩토링이 필요합니다.

1. year, month 기준으로 쿼리스트링 수정 
2. 아예 제거하고, Context를 사용하는것도 대안이 될 것 같네용,,,

우선 임시로 동작하게 수정하였습니다


# 사진 (UI 컴포넌트 및 파일에 한해)

![Screen Recording 2022-08-16 at 4 42 21 AM](https://user-images.githubusercontent.com/64780560/184706059-53a9f3f0-f699-4a71-bacf-367bad05e3a0.gif)

